### PR TITLE
Use Java 8 as target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,8 @@
     </issueManagement>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>8</java.version>
+        <java.test.version>11</java.test.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -164,7 +165,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>${java.version}</release>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <testSource>${java.test.version}</testSource>
+                    <testTarget>${java.test.version}</testTarget>
                 </configuration>
             </plugin>
             <plugin>
@@ -184,6 +188,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.1.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
There's currently nothing requiring Java 11 in the main sources of this project and everything compiles successfully with Java 8.

It would be nice to support the "late movers" who are still on Java 8 and enable them to use this nice project in their legacy code bases.

The tests will still be compiled with Java 11 as source and target version, so that modern language constructs can be used.