### PR TITLE
Make resetAll be really called in afterEach

### DIFF
--- a/src/main/java/com/github/sparkmuse/wiremock/WiremockExtension.java
+++ b/src/main/java/com/github/sparkmuse/wiremock/WiremockExtension.java
@@ -76,8 +76,11 @@ public class WiremockExtension implements AfterAllCallback, TestInstancePostProc
      */
     @Override
     public void afterEach(ExtensionContext extensionContext) {
-        List<Field> serverFields = retrieveAnnotatedFields(extensionContext.getRoot(), Wiremock.class, WireMockServer.class);
-        ExtensionContext.Store store = getStore(extensionContext);
+        // because we are in afterEach, ExtensionContext actually is a MethodExtensionContext which always has non-empty parent
+        @SuppressWarnings("OptionalGetWithoutIsPresent")
+        ExtensionContext classContext = extensionContext.getParent().get();
+        List<Field> serverFields = retrieveAnnotatedFields(classContext, Wiremock.class, WireMockServer.class);
+        ExtensionContext.Store store = getStore(classContext);
 
         serverFields.stream()
                 .map(field -> store.get(field.getName(), WireMockServer.class))

--- a/src/test/java/com/github/sparkmuse/wiremock/samples/TestsAreIsolatedTest.java
+++ b/src/test/java/com/github/sparkmuse/wiremock/samples/TestsAreIsolatedTest.java
@@ -6,6 +6,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -14,41 +15,31 @@ import com.github.sparkmuse.wiremock.WiremockExtension;
 import com.github.tomakehurst.wiremock.WireMockServer;
 
 @ExtendWith(WiremockExtension.class)
-public class WiremockExtensionTestsAreIsolatedTest {
+public class TestsAreIsolatedTest {
 
     @Wiremock
-    private WireMockServer wiremock;
+    private WireMockServer server;
 
     private final HttpClient httpClient = HttpClient.newHttpClient();
     private final HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:8080/test")).GET().build();
 
     @Test
+    @DisplayName("test without stubs defined equals number of unmatched requests")
     void test_one() throws Exception {
-        // this test doesn't have any stubs defined
-        // any request will be treated as unmatched
 
-        // we make only two requests
         httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
-        // and as a result we have exactly two unmatched requests, not four
-        // as tests are isolated and wiremock.resetAll() is called between the tests
-        // same_as_test_one has no impact on this test
-        Assertions.assertEquals(2, wiremock.findAllUnmatchedRequests().size());
+        Assertions.assertEquals(2, server.findAllUnmatchedRequests().size());
     }
 
     @Test
+    @DisplayName("test without stubs defined equals number of unmatched requests AGAIN")
     void same_as_test_one() throws Exception {
-        // this test doesn't have any stubs defined
-        // any request will be treated as unmatched
 
-        // we make only two requests
         httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
-        // and as a result we have exactly two unmatched requests, not four
-        // as tests are isolated and wiremock.resetAll() is called between the tests
-        // test_one has no impact on this test
-        Assertions.assertEquals(2, wiremock.findAllUnmatchedRequests().size());
+        Assertions.assertEquals(2, server.findAllUnmatchedRequests().size());
     }
 }

--- a/src/test/java/com/github/sparkmuse/wiremock/samples/WiremockExtensionTestsAreIsolatedTest.java
+++ b/src/test/java/com/github/sparkmuse/wiremock/samples/WiremockExtensionTestsAreIsolatedTest.java
@@ -1,0 +1,54 @@
+package com.github.sparkmuse.wiremock.samples;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.github.sparkmuse.wiremock.Wiremock;
+import com.github.sparkmuse.wiremock.WiremockExtension;
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+@ExtendWith(WiremockExtension.class)
+public class WiremockExtensionTestsAreIsolatedTest {
+
+    @Wiremock
+    private WireMockServer wiremock;
+
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:8080/test")).GET().build();
+
+    @Test
+    void test_one() throws Exception {
+        // this test doesn't have any stubs defined
+        // any request will be treated as unmatched
+
+        // we make only two requests
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        // and as a result we have exactly two unmatched requests, not four
+        // as tests are isolated and wiremock.resetAll() is called between the tests
+        // same_as_test_one has no impact on this test
+        Assertions.assertEquals(2, wiremock.findAllUnmatchedRequests().size());
+    }
+
+    @Test
+    void same_as_test_one() throws Exception {
+        // this test doesn't have any stubs defined
+        // any request will be treated as unmatched
+
+        // we make only two requests
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        // and as a result we have exactly two unmatched requests, not four
+        // as tests are isolated and wiremock.resetAll() is called between the tests
+        // test_one has no impact on this test
+        Assertions.assertEquals(2, wiremock.findAllUnmatchedRequests().size());
+    }
+}


### PR DESCRIPTION
### The PR for the #3 issue.

Looks like in `WiremockExtension#afterEach` `List<Field> serverFields` is always empty, hence `resetAll()` is never called between tests, and request records are retained between tests. But fields are correctly found in `postProcessTestInstance` for example... (that's why WireMock instances correctly inject)

What I found, is the fact that in `WiremockExtension#postProcessTestInstance` method, `extensionContext` object, the first argument of the `retrieveAnnotatedFields` method, is the object of `org.junit.jupiter.engine.descriptor.ClassExtensionContext` class. While in the `WiremockExtension#afterEach` method, `extensionContext` object is the object of `org.junit.jupiter.engine.descriptor.MethodExtensionContext` class and `extensionContext.getRoot()` gives object of `org.junit.jupiter.engine.descriptor.JupiterEngineExtensionContext` class.

So, as we can see, we have a difference in the first arguments of the `retrieveAnnotatedFields` method:
- object of `ClassExtensionContext` class, that allows `retrieveAnnotatedFields` method correctly find fields;
- object of `JupiterEngineExtensionContext` class, that doesn't allow to do that. And from my point of view, this is quite logical, `JupiterEngineExtensionContext` doesn't have any `@Wiremock` annotated fields.

Changes of this PR could be described as "get the correct context object for `afterEach` method".
Because changes are in `afterEach` method, `ExtensionContext extensionContext` object actually will be an object of `MethodExtensionContext` class, which always has a non-empty parent (`MethodExtensionContext` constructor), that's why it's safe to call `get()` on optional.

Also, I created a test that checks tests' isolation. Without changes I've made in `WiremockExtension#afterEach` a new test fails, giving for one of the tests (for the 2nd one that will be executed) four unmatched requests instead of the expected two: 2 requests from the failed method itself and another 2 from the previously executed test.